### PR TITLE
Include ACS API key in ACS requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ bower_components
 *.swp
 npm-debug.log
 .env
+
+# Ignore app JS config file
+app/scripts/config.js

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ npm install
 bower install
 ```
 
+#### Set up ACS API key
+
+First copy the example js config file: `cp app/scripts/config.js.example app/scripts/config.js`
+
+If at Azavea, an API key for use is stored in the company password manager. Otherwise, you'll need to [sign up for a key](http://api.census.gov/data/key_signup.html).
+
+Once you have your key, add it to the appropriate spot at the top of the `app/scripts/config.js` file.
+
 #### Grunt tasks
 
 - `grunt server`: Run the development server, watching for js/css/html changes
@@ -31,6 +39,8 @@ First, ensure bower components are up to date:
 ```
 bower install
 ```
+
+Double-check that `app/scripts/config.js` has the appropriate custom values for the environment being deployed.
 
 Then, build the minified app with:
 ```

--- a/app/scripts/acs/acs-service.js
+++ b/app/scripts/acs/acs-service.js
@@ -39,6 +39,10 @@
          * @return {promise}      Promise which resolves to an object of the format described above
          */
         function getACSData(where) {
+            if (!(Config.censusApi && Config.censusApi.key)) {
+                return $q.reject('Census API key missing. See README for setup instructions.');
+            }
+
             var queryTemplate = [
                 'SELECT {state} as state, {county} as county, {tract} as tract ',
                 'FROM {tablename} ',
@@ -66,6 +70,7 @@
                     return $http.get(acsUrl, {
                         cache: true,
                         params: {
+                            key: Config.censusApi.key,
                             get: _.keys(ACSVariables).join(','),
                             for: 'tract:' + value,
                             in: key

--- a/app/scripts/config.js.example
+++ b/app/scripts/config.js.example
@@ -6,6 +6,9 @@
      * @type {Object}
      */
     var config = {
+        censusApi: {
+            key: 'add your API key here'
+        },
         bounds: {
             northEast: {
                 lat: 49.384,


### PR DESCRIPTION
## Overview

At some point the API began requiring the API key. This restores app functionality on the Museum detail page.

## Demo

<img width="980" alt="screen shot 2017-01-27 at 14 27 16" src="https://cloud.githubusercontent.com/assets/1818302/22384517/be082488-e49c-11e6-98c4-09e80bc1aad1.png">

## Testing

Setup API key as described in the new README notes. ACS data should populate again on the museum detail page.
