### PR TITLE
Update Census API URL to HTTPS

### DIFF
--- a/app/scripts/acs/acs-service.js
+++ b/app/scripts/acs/acs-service.js
@@ -13,7 +13,7 @@
             tract: 'tract',
             geom: 'the_geom'
         };
-        var acsUrl = 'http://api.census.gov/data/2014/acs5';
+        var acsUrl = 'https://api.census.gov/data/2014/acs5';
 
         var module = {
             getPolygon: getPolygon,


### PR DESCRIPTION
## Overview

Updates Census API to HTTPS in preparation for deprecation of the HTTP endpoint at the end of August.

## Demo

HTTPS in console:
![screen shot 2017-08-04 at 14 11 12](https://user-images.githubusercontent.com/1818302/28981245-f91b0574-791e-11e7-8a42-8b9d6ce938cd.png)

Trivial, merging this. 

Closes #155 