### PR TITLE
Convert geocoder URLs to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Development
 
 #### Prerequisites
-- nodejs 0.12+
+- nodejs >0.12 and <12 . Node 8 seems to work. You will likely need to install nvm to use an older version of node.
 - ruby
 - ruby gem package manager
 

--- a/app/scripts/geocoder/geocoder-service.js
+++ b/app/scripts/geocoder/geocoder-service.js
@@ -6,9 +6,9 @@
     function Geocoder ($http, $log, $q, Config) {
 
         // Private variables
-        var searchUrl = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find';
-        var suggestUrl = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest';
-        var reverseUrl = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode';
+        var searchUrl = 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find';
+        var suggestUrl = 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest';
+        var reverseUrl = 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode';
         var boundingBox = [
             Config.bounds.southWest.lng,
             Config.bounds.southWest.lat,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": {},
   "devDependencies": {
     "grunt": "0.4.5",
+    "grunt-cli": "1.2.0",
     "grunt-autoprefixer": "2.0.0",
     "grunt-concurrent": "1.0.0",
     "grunt-contrib-clean": "0.6.0",
@@ -15,7 +16,7 @@
     "grunt-contrib-cssmin": "0.12.0",
     "grunt-contrib-htmlmin": "0.4.0",
     "grunt-contrib-imagemin": "1.0.0",
-    "grunt-contrib-jshint": "0.11.0",
+    "grunt-contrib-jshint": "0.12.0",
     "grunt-contrib-uglify": "0.7.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-filerev": "2.1.2",
@@ -40,6 +41,7 @@
     "node": ">=0.12.0"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "serve": "grunt serve"
   }
 }


### PR DESCRIPTION
## Overview

The ArcGIS geocoder URL that the app uses is in http, but the geocoder now returns a `400` status code for geocoding requests that are not over https. This has caused the search functionality on MuseumStat to break. This fixes the issue. ImpactView is unaffected (the relevant URLs are already https).

Also includes some miscellaneous baby steps toward best practices that I made when trying to get the app working again. I ultimately ended up not using them but they should be harmless and may make things easier if we ever get funding for this app again.

## Testing instructions

- If you can easily get the app running, confirm that the search functionality works. But this is pro-bono so don't try too hard.
- If you can't, just inspecting the code is fine; you can compare the behavior of http://museumstat.org and https://impactview.org to see live examples of the difference.
